### PR TITLE
Fix dep ordering.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,8 @@ src/p4ofagent.c                    \
 src/parse.c                        \
 src/state.c
 
-p4ofagent : all
+indigo-lib:
 	make -f indigo-lib.mk indigo-lib
+
+p4ofagent: indigo-lib all 
 	ar -M <libp4ofagent.mri


### PR DESCRIPTION
Forces indigo library to be built before p4ofagent library. This is necessary because the dependmodules.x file, generated when building indigo library, is required to compile p4ofagent library.